### PR TITLE
Add taskList attribute to Event class for project restructuring

### DIFF
--- a/src/main/java/seedu/duke/Duke.java
+++ b/src/main/java/seedu/duke/Duke.java
@@ -13,6 +13,8 @@ import java.util.ArrayList;
 public class Duke {
 
     public static ArrayList<Event> eventCatalog = new ArrayList<>();
+    /*TODO: Delete the ArrayList of tasks below once the project has been restructured to fully utilize the new
+    *  ArrayList of Task objects within each Event*/
     public static ArrayList<Task> taskList = new ArrayList<>();
     private static final StorageFile storage = new StorageFile();
 

--- a/src/main/java/seedu/duke/Duke.java
+++ b/src/main/java/seedu/duke/Duke.java
@@ -4,7 +4,6 @@ import seedu.duke.commands.ByeCommand;
 import seedu.duke.commands.Command;
 import seedu.duke.commands.CommandResult;
 import seedu.duke.items.Event;
-import seedu.duke.items.Item;
 import seedu.duke.items.Task;
 import seedu.duke.storage.StorageFile;
 
@@ -13,19 +12,19 @@ import java.util.ArrayList;
 
 public class Duke {
 
-    public static ArrayList<Event> eventList = new ArrayList<>();
+    public static ArrayList<Event> eventCatalog = new ArrayList<>();
     public static ArrayList<Task> taskList = new ArrayList<>();
     private static final StorageFile storage = new StorageFile();
 
     public static void main(String[] args) {
         Ui.printGreetingMessage();
         try {
-            storage.load(eventList, taskList);
+            storage.load(eventCatalog, taskList);
         } catch (FileNotFoundException e) {
             System.out.println("Oooh a new user!");
         }
         runSlam();
-        storage.save(eventList, taskList);
+        storage.save(eventCatalog, taskList);
     }
 
     protected static void runSlam() {

--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -10,10 +10,8 @@ import seedu.duke.commands.SelectCommand;
 import seedu.duke.commands.Command;
 import seedu.duke.commands.DeleteCommand;
 import seedu.duke.commands.FindCommand;
-import seedu.duke.commands.HelpCommand;
 import seedu.duke.commands.ListCommand;
 import seedu.duke.commands.NextCommand;
-import seedu.duke.commands.SelectCommand;
 import seedu.duke.commands.UpdateCommand;
 import seedu.duke.items.Item;
 
@@ -88,7 +86,7 @@ public class Parser {
 
     public static ArrayList<Item> makeMainList() {
         ArrayList<Item> sortedList = new ArrayList<>();
-        sortedList.addAll(Duke.eventList);
+        sortedList.addAll(Duke.eventCatalog);
         sortedList.addAll(Duke.taskList);
         return sortedList;
     }

--- a/src/main/java/seedu/duke/Ui.java
+++ b/src/main/java/seedu/duke/Ui.java
@@ -66,7 +66,7 @@ public class Ui {
     public static String getEventAddedMessage(Event event) {
         return String.format("Event added: %s\n"
                         + "Total number of events = %s",
-                event.getTitle(), Duke.eventList.size());
+                event.getTitle(), Duke.eventCatalog.size());
     }
 
     public static void printGreetingMessage() {

--- a/src/main/java/seedu/duke/commands/AddCommand.java
+++ b/src/main/java/seedu/duke/commands/AddCommand.java
@@ -157,7 +157,7 @@ public class AddCommand extends Command {
     }
 
     private static void addToEventList(Event event) {
-        Duke.eventList.add(event);
+        Duke.eventCatalog.add(event);
     }
 
     public CommandResult execute() {

--- a/src/main/java/seedu/duke/commands/DeleteCommand.java
+++ b/src/main/java/seedu/duke/commands/DeleteCommand.java
@@ -5,7 +5,7 @@ import seedu.duke.items.Item;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import static seedu.duke.Duke.eventList;
+import static seedu.duke.Duke.eventCatalog;
 import static seedu.duke.Duke.taskList;
 
 public class DeleteCommand extends Command {
@@ -34,7 +34,7 @@ public class DeleteCommand extends Command {
 
     public static void fillCombinedItemList() {
         combinedItemList.clear();
-        combinedItemList.addAll(eventList);
+        combinedItemList.addAll(eventCatalog);
         combinedItemList.addAll(taskList);
     }
 

--- a/src/main/java/seedu/duke/commands/DoneUndoCommand.java
+++ b/src/main/java/seedu/duke/commands/DoneUndoCommand.java
@@ -44,7 +44,7 @@ public class DoneUndoCommand extends Command {
                             + "mark done or undo. ");
                 }
                 indexes = command[2].split(",");
-                sortedList = new ArrayList<>(Duke.eventList);
+                sortedList = new ArrayList<>(Duke.eventCatalog);
                 Parser.bubbleSortItems(sortedList);
             } else {
                 indexes = command[1].split(",");

--- a/src/main/java/seedu/duke/commands/ListCommand.java
+++ b/src/main/java/seedu/duke/commands/ListCommand.java
@@ -37,7 +37,7 @@ public class ListCommand extends Command {
             Ui.printList(sortedList);
             break;
         case "event":
-            sortedList = new ArrayList<>(Duke.eventList);
+            sortedList = new ArrayList<>(Duke.eventCatalog);
             Parser.bubbleSortItems(sortedList);
             System.out.println("Here are all the events in your list:");
             Ui.printList(sortedList);

--- a/src/main/java/seedu/duke/commands/UpdateCommand.java
+++ b/src/main/java/seedu/duke/commands/UpdateCommand.java
@@ -67,7 +67,7 @@ public class UpdateCommand extends Command {
     protected void updateDate(Integer index, String attribute) {
         try {
             if (this.listType.equalsIgnoreCase("-e")) {
-                Event itemToBeUpdated = Duke.eventList.get(index);
+                Event itemToBeUpdated = Duke.eventCatalog.get(index);
                 String newDate = retrieveItemAttribute(attribute, DATE_FLAG);
                 itemToBeUpdated.setDateTime(Parser.convertDateTime(newDate));
             } else if (this.listType.equalsIgnoreCase("-t")) {
@@ -83,7 +83,7 @@ public class UpdateCommand extends Command {
 
     protected void updateTitle(Integer index, String attribute) {
         if (this.listType.equalsIgnoreCase("-e")) {
-            Event itemToBeUpdated = Duke.eventList.get(index);
+            Event itemToBeUpdated = Duke.eventCatalog.get(index);
             String newTitle = retrieveItemAttribute(attribute, TITLE_FLAG);
             itemToBeUpdated.setTitle(newTitle);
         } else if (this.listType.equalsIgnoreCase("-t")) {
@@ -95,7 +95,7 @@ public class UpdateCommand extends Command {
 
     protected void updateVenue(Integer index, String attribute) {
         if (this.listType.equalsIgnoreCase("-e")) {
-            Event itemToBeUpdated = Duke.eventList.get(index);
+            Event itemToBeUpdated = Duke.eventCatalog.get(index);
             String newVenue = retrieveItemAttribute(attribute, VENUE_FLAG);
             itemToBeUpdated.setVenue(newVenue);
         } else if (this.listType.equalsIgnoreCase("-t")) {
@@ -106,7 +106,7 @@ public class UpdateCommand extends Command {
     protected void updateBudget(Integer index, String attribute) {
         try {
             if (this.listType.equalsIgnoreCase("-e")) {
-                Event itemToBeUpdated = Duke.eventList.get(index);
+                Event itemToBeUpdated = Duke.eventCatalog.get(index);
                 double newBudget = retrieveEventBudget(attribute);
                 itemToBeUpdated.setBudget(newBudget);
             } else if (this.listType.equalsIgnoreCase("-t")) {
@@ -119,7 +119,7 @@ public class UpdateCommand extends Command {
 
     protected void updateDescription(Integer index, String attribute) {
         if (this.listType.equalsIgnoreCase("-e")) {
-            Event itemToBeUpdated = Duke.eventList.get(index);
+            Event itemToBeUpdated = Duke.eventCatalog.get(index);
             String newDescription = retrieveItemAttribute(attribute, DESCRIPTION_FLAG);
             itemToBeUpdated.setDescription(newDescription);
         } else if (this.listType.equalsIgnoreCase("-t")) {

--- a/src/main/java/seedu/duke/items/Event.java
+++ b/src/main/java/seedu/duke/items/Event.java
@@ -1,9 +1,12 @@
 package seedu.duke.items;
 
+import java.lang.reflect.Array;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 
 public class Event extends Item {
 
+    private ArrayList<Task> taskList = new ArrayList<>();
     private LocalDateTime dateTime;
     private String venue;
     private double budget;
@@ -42,6 +45,10 @@ public class Event extends Item {
 
     public double getBudget() {
         return budget;
+    }
+
+    public ArrayList<Task> getTaskList() {
+        return taskList;
     }
 
     @Override

--- a/src/main/java/seedu/duke/items/Event.java
+++ b/src/main/java/seedu/duke/items/Event.java
@@ -1,6 +1,5 @@
 package seedu.duke.items;
 
-import java.lang.reflect.Array;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 

--- a/src/main/java/seedu/duke/items/Event.java
+++ b/src/main/java/seedu/duke/items/Event.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 
 public class Event extends Item {
 
-    private ArrayList<Task> taskList = new ArrayList<>();
+    public ArrayList<Task> taskList = new ArrayList<>();
     private LocalDateTime dateTime;
     private String venue;
     private double budget;


### PR DESCRIPTION
Instead of having two separate global `ArrayList` for `Event` and `Task` objects, an additional `ArrayList<Task>` attribute is added to the `Event` class. The attribute is made `public` for now since the classes within the `commands` package are required to frequently modify and access this attribute. The goal behind this is to allow for added tasks to be tagged/nested under events that have been created, which much greater aligns with the initial design philosophy of the project.

To-do: 
- Update respective commands to incorporate usage of this new attribute such that there is no longer a need for a global `taskList` in `main` 
- In particular, the `select` command should now act as a "primer" of sorts to prepare the other commands (e.g. an event first needs to be selected first before a task can be added to it) 
- Update save/load functionalities so that it is compatible with the new structure of how events and tasks are stored 
- Delete the current global `taskList` once the above is completed. 