### PR TITLE
Add skeleton and example for Parser Restructure

### DIFF
--- a/src/main/java/seedu/duke/exceptions/parserexceptions/AttributeNotFoundException.java
+++ b/src/main/java/seedu/duke/exceptions/parserexceptions/AttributeNotFoundException.java
@@ -1,0 +1,17 @@
+package seedu.duke.exceptions.parserexceptions;
+
+import seedu.duke.parser.ItemAttribute;
+
+public class AttributeNotFoundException extends Exception {
+
+    private final ItemAttribute itemAttribute;
+
+    public AttributeNotFoundException(ItemAttribute itemAttribute) {
+        super();
+        this.itemAttribute = itemAttribute;
+    }
+
+    public ItemAttribute getItemAttribute() {
+        return itemAttribute;
+    }
+}

--- a/src/main/java/seedu/duke/exceptions/parserexceptions/InvalidBudgetException.java
+++ b/src/main/java/seedu/duke/exceptions/parserexceptions/InvalidBudgetException.java
@@ -1,0 +1,8 @@
+package seedu.duke.exceptions.parserexceptions;
+
+public class InvalidBudgetException extends Exception {
+
+    public InvalidBudgetException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/seedu/duke/exceptions/parserexceptions/InvalidItemTypeException.java
+++ b/src/main/java/seedu/duke/exceptions/parserexceptions/InvalidItemTypeException.java
@@ -1,0 +1,7 @@
+package seedu.duke.exceptions.parserexceptions;
+
+public class InvalidItemTypeException extends Exception {
+    public InvalidItemTypeException() {
+        super();
+    }
+}

--- a/src/main/java/seedu/duke/exceptions/parserexceptions/NoCommandAttributesException.java
+++ b/src/main/java/seedu/duke/exceptions/parserexceptions/NoCommandAttributesException.java
@@ -1,0 +1,7 @@
+package seedu.duke.exceptions.parserexceptions;
+
+public class NoCommandAttributesException extends Exception {
+    public NoCommandAttributesException() {
+        super();
+    }
+}

--- a/src/main/java/seedu/duke/parser/ItemAttribute.java
+++ b/src/main/java/seedu/duke/parser/ItemAttribute.java
@@ -1,0 +1,37 @@
+package seedu.duke.parser;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum ItemAttribute {
+    TITLE("title", "n/"),
+    DATE("date", "d/"),
+    VENUE("venue", "v/"),
+    BUDGET("budget", "b/");
+
+    private static final Map<ItemAttribute, String> BY_ATTRIBUTE_NAME = new HashMap<>();
+    private static final Map<ItemAttribute, String> BY_ATTRIBUTE_FLAG = new HashMap<>();
+
+    static {
+        for (ItemAttribute itemAttribute : values()) {
+            BY_ATTRIBUTE_NAME.put(itemAttribute, itemAttribute.attributeName);
+            BY_ATTRIBUTE_FLAG.put(itemAttribute, itemAttribute.attributeFlag);
+        }
+    }
+
+    private final String attributeName;
+    private final String attributeFlag;
+
+    ItemAttribute(String attributeName, String attributeFlag) {
+        this.attributeName = attributeName;
+        this.attributeFlag = attributeFlag;
+    }
+
+    public static String getAttributeName(ItemAttribute itemAttribute) {
+        return BY_ATTRIBUTE_NAME.get(itemAttribute);
+    }
+
+    public static String getItemFlag(ItemAttribute itemAttribute) {
+        return BY_ATTRIBUTE_FLAG.get(itemAttribute);
+    }
+}

--- a/src/main/java/seedu/duke/parser/ItemType.java
+++ b/src/main/java/seedu/duke/parser/ItemType.java
@@ -1,0 +1,7 @@
+package seedu.duke.parser;
+
+public enum ItemType {
+    EVENT,
+    TASK,
+    MEMBER
+}

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -68,10 +68,11 @@ public abstract class Parser {
     }
 
     /**
-     * Gets the item type (event, task or member) of the command given user input with the command type (add, delete etc)
-     * filtered off.
+     * Gets the item type (event, task or member) of the command given user input with the command
+     * type (add, delete etc) filtered off.
      *
-     * @param commandDetails Details of the command containing only the item flag and its attributes (e.g. "-e n/TITLE...")
+     * @param commandDetails Details of the command containing only the item flag and its
+     *                       attributes (e.g. "-e n/TITLE...")
      * @return The specified item type of the user command
      * @throws InvalidItemTypeException If there is no flag detected that is valid
      */
@@ -117,7 +118,7 @@ public abstract class Parser {
      * @return The parsed attribute (does not contain the attribute flag) that was found.
      * @throws AttributeNotFoundException If no such attribute is found within the provided string.
      */
-    protected static String retrieveItemAttribute (String response, ItemAttribute itemAttribute)
+    protected static String retrieveItemAttribute(String response, ItemAttribute itemAttribute)
             throws AttributeNotFoundException {
         int startOfItemAttribute = response.indexOf(ItemAttribute.getItemFlag(itemAttribute)) + 2;
         int endOfItemAttribute = response.indexOf("/", startOfItemAttribute) - 2;

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -34,9 +34,12 @@ public abstract class Parser {
 
     public static Command parseCommand(String response) throws DukeException {
         // Trim and split response using first detected occurrence of whitespace(s) to get type of command requested
-        String[] command = response.trim().split(" +", 1);
+        String[] command = response.trim().split(" +");
+
+        // TODO: Once parser is restructured, replace above with following two lines
+        //String[] command = response.trim().split(" +");
+        //String commandDetails = command[1];
         String commandType = command[0];
-        String commandDetails = command[1];
 
         switch (commandType) {
         case "list":

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -16,22 +16,29 @@ import seedu.duke.commands.ListCommand;
 import seedu.duke.commands.NextCommand;
 import seedu.duke.commands.UpdateCommand;
 import seedu.duke.exceptions.DukeException;
+import seedu.duke.exceptions.parserexceptions.AttributeNotFoundException;
+import seedu.duke.exceptions.parserexceptions.InvalidItemTypeException;
+import seedu.duke.exceptions.parserexceptions.NoCommandAttributesException;
 import seedu.duke.items.Item;
+import seedu.duke.parser.commandparser.AddParser;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 
 
-public class Parser {
 public abstract class Parser {
     protected static DateTimeFormatter formatter1 = DateTimeFormatter.ofPattern("dd-MM-yyyy HHmm");
     protected static DateTimeFormatter formatter2 = DateTimeFormatter.ofPattern("d MMM yyyy - HH:mm");
     private static int indexOfLastSelectedEvent = -1;
 
     public static Command parseCommand(String response) throws DukeException {
-        String[] command = response.split(" +");
-        switch (command[0]) {
+        // Trim and split response using first detected occurrence of whitespace(s) to get type of command requested
+        String[] command = response.trim().split(" +", 1);
+        String commandType = command[0];
+        String commandDetails = command[1];
+
+        switch (commandType) {
         case "list":
             return new ListCommand(command);
         case "done":
@@ -41,6 +48,8 @@ public abstract class Parser {
             return new DeleteCommand(command);
         case "add":
             return new AddCommand(command, response);
+            // TODO: Replace with the following commented out code
+            // return AddParser.getAddCommand(commandDetails);
         case "bye":
             return new ByeCommand();
         case "help":
@@ -57,6 +66,76 @@ public abstract class Parser {
             throw new DukeException(Ui.getInvalidCommandMessage());
         }
     }
+
+    /**
+     * Gets the item type (event, task or member) of the command given user input with the command type (add, delete etc)
+     * filtered off.
+     *
+     * @param commandDetails Details of the command containing only the item flag and its attributes (e.g. "-e n/TITLE...")
+     * @return The specified item type of the user command
+     * @throws InvalidItemTypeException If there is no flag detected that is valid
+     */
+    protected static ItemType getItemType(String commandDetails) throws InvalidItemTypeException {
+        String itemFlagDeclaration = (commandDetails.trim().split(" +"))[0];
+        switch (itemFlagDeclaration) {
+        case "-e":
+            return ItemType.EVENT;
+        case "-t":
+            return ItemType.TASK;
+        case "-m":
+            return ItemType.MEMBER;
+        default:
+            throw new InvalidItemTypeException();
+        }
+    }
+
+    /**
+     * Gets the combined string of command attributes given user input with the command type (add, delete etc)
+     * filtered off.
+     *
+     * @param commandDetails String containing details of the command
+     * @return The combined string of command attributes e.g. "n/TITLE d/DATE v/VENUE b/BUDGET"
+     * @throws NoCommandAttributesException If there is no command attributes detected
+     */
+    protected static String getCommandAttributes(String commandDetails) throws NoCommandAttributesException {
+        String[] commandAttributes = (commandDetails.trim().split(" +"));
+
+        if (commandAttributes.length < 2) {
+            throw new NoCommandAttributesException();
+        }
+
+        return commandAttributes[1];
+    }
+
+    // @@author Alvinlj00
+    /**
+     * Takes in an item attribute and searches the response String (e.g. commandDetails) for the item attribute, and
+     * returns the parsed attribute.
+     *
+     * @param response User input/details regarding the command to search the attribute for.
+     * @param itemAttribute The item attribute to search for (e.g. title, venue etc.).
+     * @return The parsed attribute (does not contain the attribute flag) that was found.
+     * @throws AttributeNotFoundException If no such attribute is found within the provided string.
+     */
+    protected static String retrieveItemAttribute (String response, ItemAttribute itemAttribute)
+            throws AttributeNotFoundException {
+        int startOfItemAttribute = response.indexOf(ItemAttribute.getItemFlag(itemAttribute)) + 2;
+        int endOfItemAttribute = response.indexOf("/", startOfItemAttribute) - 2;
+
+        String result;
+        if (endOfItemAttribute < 0) {
+            result = response.trim().substring(startOfItemAttribute);
+        } else {
+            result = response.trim().substring(startOfItemAttribute, endOfItemAttribute);
+        }
+
+        if (result.isBlank()) {
+            throw new AttributeNotFoundException(itemAttribute);
+        }
+
+        return result;
+    }
+    // @@author
 
     public static String convertDateTime(LocalDateTime dateTime) {
         return dateTime.format(formatter2);

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 
 
 public class Parser {
+public abstract class Parser {
     protected static DateTimeFormatter formatter1 = DateTimeFormatter.ofPattern("dd-MM-yyyy HHmm");
     protected static DateTimeFormatter formatter2 = DateTimeFormatter.ofPattern("d MMM yyyy - HH:mm");
     private static int indexOfLastSelectedEvent = -1;

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -145,8 +145,13 @@ public abstract class Parser {
         return dateTime.format(formatter2);
     }
 
-    public static LocalDateTime convertDateTime(String dateTime) {
-        return LocalDateTime.parse(dateTime, formatter1);
+    public static LocalDateTime convertDateTime(String dateTime) throws DukeException {
+        LocalDateTime result = LocalDateTime.parse(dateTime, formatter1);
+        if (result.isBefore(LocalDateTime.now())) {
+            throw new DukeException("Unfortunately, we cannot travel back in time. Please "
+                    + "enter a valid date and time in the format 'dd-MM-yyyy HHmm'. ");
+        }
+        return result;
     }
 
     public static String convertDateTimeForSaving(LocalDateTime dateTime) {

--- a/src/main/java/seedu/duke/parser/commandparser/AddParser.java
+++ b/src/main/java/seedu/duke/parser/commandparser/AddParser.java
@@ -2,7 +2,6 @@ package seedu.duke.parser.commandparser;
 
 import seedu.duke.commands.Command;
 import seedu.duke.commands.HelpCommand;
-import seedu.duke.exceptions.DukeException;
 import seedu.duke.exceptions.parserexceptions.AttributeNotFoundException;
 import seedu.duke.exceptions.parserexceptions.InvalidItemTypeException;
 import seedu.duke.exceptions.parserexceptions.NoCommandAttributesException;
@@ -84,6 +83,14 @@ public abstract class AddParser extends Parser {
                     + attributeFlag + attributeType.toUpperCase());
         }
 
+        return null;
+    }
+
+    private static String[] parseAddTask(String commandDetails) {
+        return null;
+    }
+
+    private static String[] parsedAddMember(String commandDetails) {
         return null;
     }
 }

--- a/src/main/java/seedu/duke/parser/commandparser/AddParser.java
+++ b/src/main/java/seedu/duke/parser/commandparser/AddParser.java
@@ -1,5 +1,6 @@
 package seedu.duke.parser.commandparser;
 
+import seedu.duke.Ui;
 import seedu.duke.commands.Command;
 import seedu.duke.commands.HelpCommand;
 import seedu.duke.exceptions.parserexceptions.AttributeNotFoundException;
@@ -34,6 +35,7 @@ public abstract class AddParser extends Parser {
                 String dateTime = parsedAttributes[INDEX_OF_DATETIME];
                 String venue = parsedAttributes[INDEX_OF_VENUE];
                 String budget = parsedAttributes[INDEX_OF_BUDGET];
+                String description = Ui.readInput().trim();
                 // TODO: Create relevant constructor for AddEventCommand and return it.
                 // return new AddEventCommand(title, dateTime, venue, budget);
 

--- a/src/main/java/seedu/duke/parser/commandparser/AddParser.java
+++ b/src/main/java/seedu/duke/parser/commandparser/AddParser.java
@@ -3,12 +3,17 @@ package seedu.duke.parser.commandparser;
 import seedu.duke.Ui;
 import seedu.duke.commands.Command;
 import seedu.duke.commands.HelpCommand;
+import seedu.duke.exceptions.DukeException;
 import seedu.duke.exceptions.parserexceptions.AttributeNotFoundException;
+import seedu.duke.exceptions.parserexceptions.InvalidBudgetException;
 import seedu.duke.exceptions.parserexceptions.InvalidItemTypeException;
 import seedu.duke.exceptions.parserexceptions.NoCommandAttributesException;
 import seedu.duke.parser.ItemAttribute;
 import seedu.duke.parser.ItemType;
 import seedu.duke.parser.Parser;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 public abstract class AddParser extends Parser {
 
@@ -32,9 +37,9 @@ public abstract class AddParser extends Parser {
                 String[] parsedAttributes = parseAddEvent(commandDetails);
                 assert parsedAttributes != null : "parseAddEvent failed";
                 String title = parsedAttributes[INDEX_OF_TITLE];
-                String dateTime = parsedAttributes[INDEX_OF_DATETIME];
+                LocalDateTime dateTime = convertDateTime(parsedAttributes[INDEX_OF_DATETIME]);
                 String venue = parsedAttributes[INDEX_OF_VENUE];
-                String budget = parsedAttributes[INDEX_OF_BUDGET];
+                Double budget = convertEventBudgetToDouble(parsedAttributes[INDEX_OF_BUDGET]);
                 String description = Ui.readInput().trim();
                 // TODO: Create relevant constructor for AddEventCommand and return it.
                 // return new AddEventCommand(title, dateTime, venue, budget);
@@ -51,6 +56,8 @@ public abstract class AddParser extends Parser {
         } catch (InvalidItemTypeException e) {
             System.out.println("Having some trouble understanding what exactly you're trying to add!\n"
                     + "TIP: Specify event '-e', task '-t', or member '-m' after the 'add' command.");
+        } catch (InvalidBudgetException | DukeException e) {
+            System.out.println(e.getMessage());
         }
 
         return null;
@@ -96,5 +103,35 @@ public abstract class AddParser extends Parser {
 
     private static String[] parsedAddMember(String commandDetails) {
         return null;
+    }
+
+    /**
+     * Converts a budget as a string and formats it into a double.
+     *
+     * @param budget The budget provided as a String
+     * @return The converted budget as a double
+     * @throws InvalidBudgetException If the provided budget converts into a negative number of has more than 2 decimals
+     */
+    private double convertEventBudgetToDouble(String budget) throws InvalidBudgetException {
+        Double result = null;
+        try {
+            result = Double.parseDouble(budget);
+            if (result < 0) {
+                throw new InvalidBudgetException("Event budget needs to be a positive number.");
+            }
+
+            if (BigDecimal.valueOf(result).scale() > 2) {
+                throw new InvalidBudgetException("Event budget cannot have more than 2 decimal places.");
+            }
+        } catch (NumberFormatException e) {
+            System.out.println("Event budget needs to be a number.");
+        }
+
+        // If conditional checks above fail internally, result will remain null. Throw exception
+        if (result == null) {
+            throw new InvalidBudgetException("Event budget is null!");
+        }
+
+        return result;
     }
 }

--- a/src/main/java/seedu/duke/parser/commandparser/AddParser.java
+++ b/src/main/java/seedu/duke/parser/commandparser/AddParser.java
@@ -45,6 +45,8 @@ public abstract class AddParser extends Parser {
                 return new HelpCommand();
             case MEMBER:
                 return new HelpCommand();
+            default:
+                return null;
             }
         } catch (InvalidItemTypeException e) {
             System.out.println("Having some trouble understanding what exactly you're trying to add!\n"
@@ -63,17 +65,17 @@ public abstract class AddParser extends Parser {
     private static String[] parseAddEvent(String commandDetails) {
         try {
             String commandAttributes = getCommandAttributes(commandDetails);
+            String[] parsedAttributes = new String[4];
 
             String title = retrieveItemAttribute(commandAttributes, ItemAttribute.TITLE);
-            String dateTime = retrieveItemAttribute(commandAttributes, ItemAttribute.DATE);
-            String venue = retrieveItemAttribute(commandAttributes, ItemAttribute.VENUE);
-            String budget = retrieveItemAttribute(commandAttributes, ItemAttribute.BUDGET);
-
-            String[] parsedAttributes = new String[4];
             parsedAttributes[INDEX_OF_TITLE] = title;
+            String dateTime = retrieveItemAttribute(commandAttributes, ItemAttribute.DATE);
             parsedAttributes[INDEX_OF_DATETIME] = dateTime;
+            String venue = retrieveItemAttribute(commandAttributes, ItemAttribute.VENUE);
             parsedAttributes[INDEX_OF_VENUE] = venue;
+            String budget = retrieveItemAttribute(commandAttributes, ItemAttribute.BUDGET);
             parsedAttributes[INDEX_OF_BUDGET] = budget;
+
             return parsedAttributes;
         } catch (NoCommandAttributesException e) {
             System.out.println("No details about the event you're trying to add is given!\n"

--- a/src/main/java/seedu/duke/parser/commandparser/AddParser.java
+++ b/src/main/java/seedu/duke/parser/commandparser/AddParser.java
@@ -1,0 +1,89 @@
+package seedu.duke.parser.commandparser;
+
+import seedu.duke.commands.Command;
+import seedu.duke.commands.HelpCommand;
+import seedu.duke.exceptions.DukeException;
+import seedu.duke.exceptions.parserexceptions.AttributeNotFoundException;
+import seedu.duke.exceptions.parserexceptions.InvalidItemTypeException;
+import seedu.duke.exceptions.parserexceptions.NoCommandAttributesException;
+import seedu.duke.parser.ItemAttribute;
+import seedu.duke.parser.ItemType;
+import seedu.duke.parser.Parser;
+
+public abstract class AddParser extends Parser {
+
+    private static final int INDEX_OF_TITLE = 0;
+    private static final int INDEX_OF_DATETIME = 1;
+    private static final int INDEX_OF_VENUE = 2;
+    private static final int INDEX_OF_BUDGET = 3;
+
+    /**
+     * Parses add command details from user input to determine the type of item to be added along with its respective
+     * attributes and returns the respective Add Command.
+     *
+     * @param commandDetails User input containing the flag of the item to be added and attributes for the command
+     * @return The constructed Add Command. Null otherwise.
+     */
+    public Command getAddCommand(String commandDetails) {
+        try {
+            ItemType itemTypeToAdd = getItemType(commandDetails);
+            switch (itemTypeToAdd) {
+            case EVENT:
+                String[] parsedAttributes = parseAddEvent(commandDetails);
+                assert parsedAttributes != null : "parseAddEvent failed";
+                String title = parsedAttributes[INDEX_OF_TITLE];
+                String dateTime = parsedAttributes[INDEX_OF_DATETIME];
+                String venue = parsedAttributes[INDEX_OF_VENUE];
+                String budget = parsedAttributes[INDEX_OF_BUDGET];
+                // TODO: Create relevant constructor for AddEventCommand and return it.
+                // return new AddEventCommand(title, dateTime, venue, budget);
+
+                // TODO: Delete the HelpCommands after they have been replaced.
+                return new HelpCommand();
+            case TASK:
+                return new HelpCommand();
+            case MEMBER:
+                return new HelpCommand();
+            }
+        } catch (InvalidItemTypeException e) {
+            System.out.println("Having some trouble understanding what exactly you're trying to add!\n"
+                    + "TIP: Specify event '-e', task '-t', or member '-m' after the 'add' command.");
+        }
+
+        return null;
+    }
+
+    /**
+     * Takes in command details for an event and returns a String[] containing the parsed attributes for that event.
+     *
+     * @param commandDetails String that contains command attributes and a redundant event flag.
+     * @return The String[] of parsed attributes for an event. Null otherwise.
+     */
+    private static String[] parseAddEvent(String commandDetails) {
+        try {
+            String commandAttributes = getCommandAttributes(commandDetails);
+
+            String title = retrieveItemAttribute(commandAttributes, ItemAttribute.TITLE);
+            String dateTime = retrieveItemAttribute(commandAttributes, ItemAttribute.DATE);
+            String venue = retrieveItemAttribute(commandAttributes, ItemAttribute.VENUE);
+            String budget = retrieveItemAttribute(commandAttributes, ItemAttribute.BUDGET);
+
+            String[] parsedAttributes = new String[4];
+            parsedAttributes[INDEX_OF_TITLE] = title;
+            parsedAttributes[INDEX_OF_DATETIME] = dateTime;
+            parsedAttributes[INDEX_OF_VENUE] = venue;
+            parsedAttributes[INDEX_OF_BUDGET] = budget;
+            return parsedAttributes;
+        } catch (NoCommandAttributesException e) {
+            System.out.println("No details about the event you're trying to add is given!\n"
+                    + "Format: add -e n/TITLE d/dd-MM-yyyy HHmm v/VENUE b/BUDGET");
+        } catch (AttributeNotFoundException e) {
+            String attributeType = ItemAttribute.getAttributeName(e.getItemAttribute());
+            String attributeFlag = ItemAttribute.getItemFlag(e.getItemAttribute());
+            System.out.println("Please add a " + attributeType + "for your event using "
+                    + attributeFlag + attributeType.toUpperCase());
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/seedu/duke/parser/commandparser/DeleteParser.java
+++ b/src/main/java/seedu/duke/parser/commandparser/DeleteParser.java
@@ -1,0 +1,11 @@
+package seedu.duke.parser.commandparser;
+
+import seedu.duke.commands.Command;
+import seedu.duke.parser.Parser;
+
+public abstract class DeleteParser extends Parser {
+
+    public Command getDeleteCommand(String commandDetails) {
+        return null;
+    }
+}

--- a/src/main/java/seedu/duke/parser/commandparser/DoneUndoneParser.java
+++ b/src/main/java/seedu/duke/parser/commandparser/DoneUndoneParser.java
@@ -1,0 +1,15 @@
+package seedu.duke.parser.commandparser;
+
+import seedu.duke.commands.Command;
+import seedu.duke.parser.Parser;
+
+public abstract class DoneUndoneParser extends Parser {
+
+    public Command getDoneCommand(String commandDetails) {
+        return null;
+    }
+
+    public Command getUndoCommand(String commandDetails) {
+        return null;
+    }
+}

--- a/src/main/java/seedu/duke/parser/commandparser/FindParser.java
+++ b/src/main/java/seedu/duke/parser/commandparser/FindParser.java
@@ -1,0 +1,11 @@
+package seedu.duke.parser.commandparser;
+
+import seedu.duke.commands.Command;
+import seedu.duke.parser.Parser;
+
+public abstract class FindParser extends Parser {
+
+    public Command getFindCommand(String commandDetails) {
+        return null;
+    }
+}

--- a/src/main/java/seedu/duke/parser/commandparser/ListParser.java
+++ b/src/main/java/seedu/duke/parser/commandparser/ListParser.java
@@ -1,0 +1,11 @@
+package seedu.duke.parser.commandparser;
+
+import seedu.duke.commands.Command;
+import seedu.duke.parser.Parser;
+
+public abstract class ListParser extends Parser {
+
+    public Command getListCommand(String commandDetails) {
+        return null;
+    }
+}

--- a/src/main/java/seedu/duke/parser/commandparser/SelectParser.java
+++ b/src/main/java/seedu/duke/parser/commandparser/SelectParser.java
@@ -1,0 +1,11 @@
+package seedu.duke.parser.commandparser;
+
+import seedu.duke.commands.Command;
+import seedu.duke.parser.Parser;
+
+public abstract class SelectParser extends Parser {
+
+    public Command getDeleteCommand(String commandDetails) {
+        return null;
+    }
+}

--- a/src/main/java/seedu/duke/parser/commandparser/UpdateParser.java
+++ b/src/main/java/seedu/duke/parser/commandparser/UpdateParser.java
@@ -1,0 +1,11 @@
+package seedu.duke.parser.commandparser;
+
+import seedu.duke.commands.Command;
+import seedu.duke.parser.Parser;
+
+public abstract class UpdateParser extends Parser {
+
+    public Command getUpdateCommand(String commandDetails) {
+        return null;
+    }
+}

--- a/src/main/java/seedu/duke/storage/EventDecoder.java
+++ b/src/main/java/seedu/duke/storage/EventDecoder.java
@@ -1,5 +1,6 @@
 package seedu.duke.storage;
 
+import seedu.duke.exceptions.DukeException;
 import seedu.duke.parser.Parser;
 import seedu.duke.items.Event;
 
@@ -15,7 +16,7 @@ public class EventDecoder {
     private static final int INDEX_OF_VENUE = 5;
     private static final int INDEX_OF_BUDGET = 6;
 
-    protected static Event decodeEventFromString(String encodedEvent) {
+    protected static Event decodeEventFromString(String encodedEvent) throws DukeException {
         String[] eventDetails = encodedEvent.trim().split(Event.EVENT_DATA_ARGS_DELIMITER);
         String eventTitle = eventDetails[INDEX_OF_TITLE];
         String eventStatus = eventDetails[INDEX_OF_STATUS];

--- a/src/main/java/seedu/duke/storage/TaskDecoder.java
+++ b/src/main/java/seedu/duke/storage/TaskDecoder.java
@@ -1,5 +1,6 @@
 package seedu.duke.storage;
 
+import seedu.duke.exceptions.DukeException;
 import seedu.duke.items.characteristics.Member;
 import seedu.duke.parser.MemberParser;
 import seedu.duke.parser.Parser;
@@ -17,7 +18,7 @@ public class TaskDecoder {
     private static final int INDEX_OF_DEADLINE = 4;
     private static final int INDEX_OF_MEMBERS = 5;
 
-    protected static Task decodeTaskFromString(String encodedTask) {
+    protected static Task decodeTaskFromString(String encodedTask) throws DukeException {
         String[] taskDetails = encodedTask.trim().split(Task.TASK_DATA_ARGS_DELIMITER);
         String taskTitle = taskDetails[INDEX_OF_TILE];
         String taskStatus = taskDetails[INDEX_OF_STATUS];

--- a/src/test/java/seedu/duke/UiTest.java
+++ b/src/test/java/seedu/duke/UiTest.java
@@ -3,6 +3,7 @@ package seedu.duke;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import seedu.duke.exceptions.DukeException;
 import seedu.duke.items.Event;
 import seedu.duke.items.Item;
 import seedu.duke.items.Task;
@@ -30,7 +31,7 @@ class UiTest {
     }
 
     @Test
-    void printList_listOfEvents_success() {
+    void printList_listOfEvents_success() throws DukeException {
         // Setting up
         LocalDateTime event1DateTime = Parser.convertDateTime("19-02-2022 2000");
         Event event1 = new Event("Peppa Pig's Concert",
@@ -54,7 +55,7 @@ class UiTest {
     }
 
     @Test
-    void printList_listOfTasks_success() {
+    void printList_listOfTasks_success() throws DukeException {
         // Setting up
         LocalDateTime task1Deadline = Parser.convertDateTime("19-02-2022 2359");
         Task task1 = new Task("Do homework", "CS2113T tp V1.0", task1Deadline);
@@ -74,7 +75,7 @@ class UiTest {
     }
 
     @Test
-    void printList_listOfEventsAndTasks_success() {
+    void printList_listOfEventsAndTasks_success() throws DukeException {
         // Setting up
         LocalDateTime eventDateTime = Parser.convertDateTime("19-02-2022 2000");
         Event event = new Event("Peppa Pig's Concert",
@@ -97,7 +98,7 @@ class UiTest {
     }
 
     @Test
-    void printEvent_oneEvent_success() {
+    void printEvent_oneEvent_success() throws DukeException {
         // Setting up
         LocalDateTime event1DateTime = Parser.convertDateTime("19-02-2022 2000");
         Event event = new Event("Peppa Pig's Concert",
@@ -122,7 +123,7 @@ class UiTest {
     }
 
     @Test
-    void printTask_oneTask_success() {
+    void printTask_oneTask_success() throws DukeException {
         // Setting up
         LocalDateTime taskDeadline = Parser.convertDateTime("19-02-2022 2359");
         Task task = new Task("Do homework", "CS2113T tp V1.0", taskDeadline);

--- a/src/test/java/seedu/duke/commands/ByeCommandTest.java
+++ b/src/test/java/seedu/duke/commands/ByeCommandTest.java
@@ -4,16 +4,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import seedu.duke.exceptions.DukeException;
-import seedu.duke.items.Event;
-import seedu.duke.items.Task;
 import seedu.duke.parser.Parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.time.LocalDateTime;
-
-import static seedu.duke.Duke.eventCatalog;
 
 public class ByeCommandTest {
     private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();

--- a/src/test/java/seedu/duke/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/duke/commands/DeleteCommandTest.java
@@ -33,7 +33,7 @@ class DeleteCommandTest {
     }
 
 
-    void setUp() {
+    void setUp() throws DukeException {
         // Setting up
         LocalDateTime event1DateTime = Parser.convertDateTime("19-02-2022 2000");
         Event event1 = new Event("Peppa Pig's Concert",

--- a/src/test/java/seedu/duke/commands/ListCommandTest.java
+++ b/src/test/java/seedu/duke/commands/ListCommandTest.java
@@ -21,7 +21,7 @@ public class ListCommandTest {
     private final PrintStream originalOut = System.out;
 
     @BeforeEach
-    public void setUpStream() {
+    public void setUpStream() throws DukeException {
         System.setOut(new PrintStream(outContent));
         setUp();
     }
@@ -84,7 +84,7 @@ public class ListCommandTest {
         assertEquals(expectedOutput, outContent.toString());
     }
 
-    void setUp() {
+    void setUp() throws DukeException {
         LocalDateTime event1DateTime = Parser.convertDateTime("19-02-2022 2000");
         Event event1 = new Event("Peppa Pig's Concert",
                 "Asia world tour", event1DateTime,

--- a/src/test/java/seedu/duke/commands/NextCommandTest.java
+++ b/src/test/java/seedu/duke/commands/NextCommandTest.java
@@ -83,7 +83,7 @@ public class NextCommandTest {
         eventCatalog.clear();
     }
 
-    void setUp() {
+    void setUp() throws DukeException {
         LocalDateTime event1DateTime = Parser.convertDateTime("19-02-2022 2000");
         Event event1 = new Event("Peppa Pig's Concert",
                 "Asia world tour", event1DateTime,

--- a/src/test/java/seedu/duke/commands/SelectCommandTest.java
+++ b/src/test/java/seedu/duke/commands/SelectCommandTest.java
@@ -27,7 +27,7 @@ class SelectCommandTest {
     }
 
 
-    private void createEventsList() {
+    private void createEventsList() throws DukeException {
         eventCatalog.clear();
         LocalDateTime event1DateTime = Parser.convertDateTime("19-02-2022 2000");
         Event event1 = new Event("Peppa Pig's Concert",

--- a/src/test/java/seedu/duke/commands/UpdateCommandTest.java
+++ b/src/test/java/seedu/duke/commands/UpdateCommandTest.java
@@ -29,7 +29,7 @@ public class UpdateCommandTest {
     }
 
     @BeforeEach
-    public void setUpStream() {
+    public void setUpStream() throws DukeException {
         System.setOut(new PrintStream(outContent));
         setUp();
     }
@@ -52,7 +52,7 @@ public class UpdateCommandTest {
         System.setIn(sysInBackup);
     }
 
-    void setUp() {
+    void setUp() throws DukeException {
         LocalDateTime event1DateTime = Parser.convertDateTime("19-02-2022 2000");
         Event event1 = new Event("Peppa Pig's Concert",
                 "Asia world tour", event1DateTime,

--- a/src/test/java/seedu/duke/storage/EventDecoderTest.java
+++ b/src/test/java/seedu/duke/storage/EventDecoderTest.java
@@ -1,6 +1,7 @@
 package seedu.duke.storage;
 
 import org.junit.jupiter.api.Test;
+import seedu.duke.exceptions.DukeException;
 import seedu.duke.items.Event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -9,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class EventDecoderTest {
 
     @Test
-    void decodeEventFromString_stringValidFormat_expectOneEvent() {
+    void decodeEventFromString_stringValidFormat_expectOneEvent() throws DukeException {
         // Setting up
         String encodedEvent = "e | Peppa Pig's Concert | X | Asia world tour | 19-02-2022 2000 "
                 + "| Indoor Stadium | 1000.9";

--- a/src/test/java/seedu/duke/storage/EventEncoderTest.java
+++ b/src/test/java/seedu/duke/storage/EventEncoderTest.java
@@ -1,6 +1,7 @@
 package seedu.duke.storage;
 
 import org.junit.jupiter.api.Test;
+import seedu.duke.exceptions.DukeException;
 import seedu.duke.items.characteristics.Member;
 import seedu.duke.parser.Parser;
 import seedu.duke.items.Event;
@@ -15,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class EventEncoderTest {
 
     @Test
-    void encodeEventsList_listOfTwoEvents_expectListOfTwoStrings() {
+    void encodeEventsList_listOfTwoEvents_expectListOfTwoStrings() throws DukeException {
         // Setting up
         ArrayList<Event> eventsList = createEventsList();
         List<String> encodedEventsList = EventEncoder.encodeEventsList(eventsList);
@@ -43,7 +44,7 @@ class EventEncoderTest {
      *
      * @return The generated list of events for testing with 2 events and 2 tasks in total.
      */
-    private ArrayList<Event> createEventsList() {
+    private ArrayList<Event> createEventsList() throws DukeException {
         LocalDateTime event1DateTime = Parser.convertDateTime("19-02-2022 2000");
         Event event1 = new Event("Peppa Pig's Concert",
                 "Asia world tour", event1DateTime,

--- a/src/test/java/seedu/duke/storage/TaskDecoderTest.java
+++ b/src/test/java/seedu/duke/storage/TaskDecoderTest.java
@@ -1,6 +1,7 @@
 package seedu.duke.storage;
 
 import org.junit.jupiter.api.Test;
+import seedu.duke.exceptions.DukeException;
 import seedu.duke.items.Task;
 import seedu.duke.items.characteristics.Member;
 
@@ -9,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class TaskDecoderTest {
 
     @Test
-    void decodeTaskFromString_stringValidFormat_expectOneTask() {
+    void decodeTaskFromString_stringValidFormat_expectOneTask() throws DukeException {
         // Setting up
         String encodedTask = "t | Do homework | X | CS2113T tp V1.0 | 19-02-2022 2359 | John_Doe Jane_Doe";
         Task decodedTask = TaskDecoder.decodeTaskFromString(encodedTask);

--- a/src/test/java/seedu/duke/storage/TaskEncoderTest.java
+++ b/src/test/java/seedu/duke/storage/TaskEncoderTest.java
@@ -1,6 +1,7 @@
 package seedu.duke.storage;
 
 import org.junit.jupiter.api.Test;
+import seedu.duke.exceptions.DukeException;
 import seedu.duke.items.Event;
 import seedu.duke.items.characteristics.Member;
 import seedu.duke.parser.Parser;
@@ -17,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class TaskEncoderTest {
 
     @Test
-    void encodeTasksList_listOfTwoTasks_expectListOfTwoStrings() {
+    void encodeTasksList_listOfTwoTasks_expectListOfTwoStrings() throws DukeException {
         // Setting up
         ArrayList<Task> tasksList = createTasksList();
         List<String> encodedTasksList = TaskEncoder.encodeTasksList(tasksList);
@@ -32,7 +33,7 @@ class TaskEncoderTest {
         assertEquals(expectedResult2, encodedTasksList.get(1));
     }
 
-    private ArrayList<Task> createTasksList() {
+    private ArrayList<Task> createTasksList() throws DukeException {
         LocalDateTime task1Deadline = Parser.convertDateTime("19-02-2022 2359");
         ArrayList<Member> memberList = new ArrayList<>();
         Task task1 = new Task("Do homework", "CS2113T tp V1.0", task1Deadline);


### PR DESCRIPTION
`Command` classes currently handle two main responsibilities - the command itself and the parsing of user input. In addition, some `Command` classes directly interact with the user. 

Restructuring how the current Parser class works will benefit the project in the following ways: 
- Allow for better design of the program in terms of SRP of classes.
- Increased standardization of how user input is parsed. 
- Easier debugging in incorrectly parsed user input. 

This PR adds a skeleton for the parser restructure and an example (adding events) as to how parsing might look like after the restructure. 

In this PR, some general methods that most `Command` specific parser subclasses should use are added. They are: 
- `getItemType()` for detecting an `Item` flag (e.g. the `-e` flag for `Event`)
- `getCommandAttributes()` for getting the chunk of attributes for the `Command`. 
- `retrieveItemAttribute()` for parsing a particular attribute of a `Command`.

To facilitate this, the `ItemType` and `ItemAttribute` enumerators were added, with the latter having multiple values attached to it that will come in useful. 

In this PR, a notable general method that is **not yet added** in this PR is one that will help parse multiple integers inputs.

Fixes #179 