### PR TITLE
New FindCommand with JUnit tests

### DIFF
--- a/src/main/java/seedu/duke/commands/FindCommand.java
+++ b/src/main/java/seedu/duke/commands/FindCommand.java
@@ -1,16 +1,42 @@
 package seedu.duke.commands;
 
 
+import seedu.duke.Duke;
+import seedu.duke.items.Event;
+
 public class FindCommand extends Command {
 
-    private final String findResults;
+    private final String keywords;
+    private static int numberOfEventsFound;
 
 
-    public FindCommand(String findResults) {
-        this.findResults = findResults;
+    public FindCommand(String keywords) {
+        this.keywords = keywords;
     }
 
     public CommandResult execute() {
+        String findResults = filterEvents(keywords);
+        if (noEventsFound()) {
+            return new CommandResult("No matching events found!");
+        }
         return new CommandResult(findResults);
+    }
+
+    private static String filterEvents(String keyword) {
+        StringBuilder result = new StringBuilder();
+        numberOfEventsFound = 0;
+        for (int i = 0; i < Duke.eventCatalog.size(); i++) {
+            Event event = Duke.eventCatalog.get(i);
+            if (event.getTitle().toLowerCase().contains(keyword.toLowerCase())) {
+                result.append(i + 1).append(". ");
+                result.append(event.getTitle()).append("\n");
+                numberOfEventsFound++;
+            }
+        }
+        return result.toString();
+    }
+
+    private static boolean noEventsFound() {
+        return numberOfEventsFound == 0;
     }
 }

--- a/src/main/java/seedu/duke/commands/FindCommand.java
+++ b/src/main/java/seedu/duke/commands/FindCommand.java
@@ -1,33 +1,16 @@
 package seedu.duke.commands;
 
-import seedu.duke.Duke;
-import seedu.duke.items.Event;
-
 
 public class FindCommand extends Command {
 
-    private final Event[] findResults;
+    private final String findResults;
 
 
-    public FindCommand(Event[] findResults) {
+    public FindCommand(String findResults) {
         this.findResults = findResults;
     }
 
     public CommandResult execute() {
-        String foundEvents;
-        foundEvents = filteredEventsAsString(findResults);
-        return new CommandResult(foundEvents);
-    }
-
-    private static String filteredEventsAsString(Event[] findResults) {
-        StringBuilder result = new StringBuilder();
-        for (int i = 0; i < findResults.length; i++) {
-            if (findResults[i] == null) {
-                continue;
-            }
-            result.append((i + 1)).append(". ").append(findResults[i].getTitle());
-            result.append("\n");
-        }
-        return result.toString();
+        return new CommandResult(findResults);
     }
 }

--- a/src/main/java/seedu/duke/commands/FindCommand.java
+++ b/src/main/java/seedu/duke/commands/FindCommand.java
@@ -12,59 +12,13 @@ public class FindCommand extends Command {
 
     private static String keyword;
     private static Event[] filteredList = new Event[MAX_SIZE];
-    //private static ArrayList<Event> filteredList = new ArrayList<>();
     private static int numberOfEvents;
 
     public FindCommand(String[] command) {
-        try {
-            if (command.length == 1) {
-                throw new DukeException("Please specify what Events you wish to find.");
-            }
-            keyword = getKeywordFromCommand(command);
-        } catch (DukeException e) {
-            System.out.println(e.getMessage());
-        } catch (StringIndexOutOfBoundsException e) {
-            System.out.println("Please enter at least one keyword!");
-        }
+
     }
 
     public CommandResult execute() {
-        filterEventsByString(keyword);
-        System.out.println("Here are the events you wished to find:");
-        printFilteredEvents();
-        if (numberOfEvents == 0) {
-            return new CommandResult("No matching events were found.");
-        }
-        return new CommandResult(numberOfEvents + " events found.");
-    }
 
-    private static String convertArrayToString(String[] command) {
-        return Arrays.toString(command);
-    }
-
-    private static String getKeywordFromCommand(String[] command) {
-        String commandAsString = convertArrayToString(command);
-        int endIndex = commandAsString.length();
-        int startOfKeyword = commandAsString.trim().indexOf(" ") + 1;
-        return commandAsString.substring(startOfKeyword, endIndex - 1).trim();
-    }
-
-    private static void filterEventsByString(String keyword) {
-        for (int i = 0; i < Duke.eventCatalog.size(); i++) {
-            Event event = Duke.eventCatalog.get(i);
-            if (event.getTitle().toLowerCase().contains(keyword.toLowerCase())) {
-                filteredList[i] = event;
-            }
-        }
-    }
-
-    private static void printFilteredEvents() {
-        for (int i = 0; i < filteredList.length; i++) {
-            if (filteredList[i] == null) {
-                continue;
-            }
-            System.out.println((i + 1) + ". " + filteredList[i].getTitle());
-            numberOfEvents++;
-        }
     }
 }

--- a/src/main/java/seedu/duke/commands/FindCommand.java
+++ b/src/main/java/seedu/duke/commands/FindCommand.java
@@ -1,24 +1,33 @@
 package seedu.duke.commands;
 
 import seedu.duke.Duke;
-import seedu.duke.exceptions.DukeException;
 import seedu.duke.items.Event;
-import java.util.Arrays;
 
 
 public class FindCommand extends Command {
 
-    private static final int MAX_SIZE = Duke.eventCatalog.size();
+    private final Event[] findResults;
 
-    private static String keyword;
-    private static Event[] filteredList = new Event[MAX_SIZE];
-    private static int numberOfEvents;
 
-    public FindCommand(String[] command) {
-
+    public FindCommand(Event[] findResults) {
+        this.findResults = findResults;
     }
 
     public CommandResult execute() {
+        String foundEvents;
+        foundEvents = filteredEventsAsString(findResults);
+        return new CommandResult(foundEvents);
+    }
 
+    private static String filteredEventsAsString(Event[] findResults) {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < findResults.length; i++) {
+            if (findResults[i] == null) {
+                continue;
+            }
+            result.append((i + 1)).append(". ").append(findResults[i].getTitle());
+            result.append("\n");
+        }
+        return result.toString();
     }
 }

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -18,6 +18,7 @@ import seedu.duke.exceptions.parserexceptions.InvalidItemTypeException;
 import seedu.duke.exceptions.parserexceptions.NoCommandAttributesException;
 import seedu.duke.items.Item;
 import seedu.duke.parser.commandparser.AddParser;
+import seedu.duke.parser.commandparser.FindParser;
 import seedu.duke.parser.commandparser.ListParser;
 import seedu.duke.parser.commandparser.NextParser;
 import seedu.duke.parser.commandparser.SelectParser;
@@ -71,7 +72,7 @@ public abstract class Parser {
         case "help":
             return new HelpCommand();
         case "find":
-            return new FindCommand(command);
+            return FindParser.getFindCommand(command, commandDetails);
         case "select":
             return SelectParser.getSelectCommand(command, commandDetails);
         case "update":

--- a/src/main/java/seedu/duke/parser/commandparser/FindParser.java
+++ b/src/main/java/seedu/duke/parser/commandparser/FindParser.java
@@ -1,11 +1,70 @@
 package seedu.duke.parser.commandparser;
 
+import seedu.duke.Duke;
 import seedu.duke.commands.Command;
+import seedu.duke.commands.FindCommand;
+import seedu.duke.exceptions.DukeException;
+import seedu.duke.exceptions.parserexceptions.InvalidItemTypeException;
+import seedu.duke.items.Event;
+import seedu.duke.parser.ItemType;
 import seedu.duke.parser.Parser;
+
+
+import static seedu.duke.parser.ItemType.EVENT;
 
 public abstract class FindParser extends Parser {
 
-    public Command getFindCommand(String commandDetails) {
+    private static final int MAX_SIZE = Duke.eventCatalog.size();
+    //private static final Event[] findResults = new Event[MAX_SIZE];
+    private static int numberOfEventsFound = 0;
+
+    public static Command getFindCommand(String[] command, String commandDetails) {
+        try {
+            ItemType itemType = getItemType(commandDetails);
+            if (itemType == EVENT) {
+                parseFindKeyword(command);
+                return new FindCommand(findResults);
+            }
+            throw new InvalidItemTypeException();
+        } catch (InvalidItemTypeException e) {
+            System.out.println("Please add -e to find event(s)!");
+        } catch (DukeException e) {
+            System.out.println(e.getMessage());
+        }
         return null;
+    }
+
+    private static void parseFindKeyword(String[] command) throws DukeException {
+        String keyword = extractKeywords(command);
+        filterEventsByKeyword(keyword);
+        if (noEventsFound()) {
+            throw new DukeException("No matching events found!");
+        }
+    }
+
+    private static String extractKeywords(String[] command) throws DukeException {
+        if (command.length < 3) {
+            throw new DukeException("Please specify what Events you wish to find!");
+        }
+        StringBuilder keyword = new StringBuilder();
+        for (int i = 2; i < command.length; i++) {
+            keyword.append(command[i].trim());
+            keyword.append(" ");
+        }
+        return keyword.toString().trim();
+    }
+
+    private static void filterEventsByKeyword(String keyword) {
+        for (int i = 0; i < MAX_SIZE; i++) {
+            Event event = Duke.eventCatalog.get(i);
+            if (event.getTitle().toLowerCase().contains(keyword.toLowerCase())) {
+                findResults[i] = event;
+                numberOfEventsFound++;
+            }
+        }
+    }
+
+    private static boolean noEventsFound() {
+        return numberOfEventsFound == 0;
     }
 }

--- a/src/main/java/seedu/duke/parser/commandparser/FindParser.java
+++ b/src/main/java/seedu/duke/parser/commandparser/FindParser.java
@@ -1,11 +1,10 @@
 package seedu.duke.parser.commandparser;
 
-import seedu.duke.Duke;
+
 import seedu.duke.commands.Command;
 import seedu.duke.commands.FindCommand;
 import seedu.duke.exceptions.DukeException;
 import seedu.duke.exceptions.parserexceptions.InvalidItemTypeException;
-import seedu.duke.items.Event;
 import seedu.duke.parser.ItemType;
 import seedu.duke.parser.Parser;
 
@@ -14,15 +13,14 @@ import static seedu.duke.parser.ItemType.EVENT;
 
 public abstract class FindParser extends Parser {
 
-    private static int numberOfEventsFound;
-    private static String result;
+    private static String keywords;
 
     public static Command getFindCommand(String[] command, String commandDetails) {
         try {
             ItemType itemType = getItemType(commandDetails);
             if (itemType == EVENT) {
                 parseFindKeyword(command);
-                return new FindCommand(result);
+                return new FindCommand(keywords);
             }
             throw new InvalidItemTypeException();
         } catch (InvalidItemTypeException e) {
@@ -34,11 +32,7 @@ public abstract class FindParser extends Parser {
     }
 
     private static void parseFindKeyword(String[] command) throws DukeException {
-        String keyword = extractKeywords(command);
-        result = filterEvents(keyword);
-        if (noEventsFound()) {
-            throw new DukeException("No matching events found!");
-        }
+        keywords = extractKeywords(command);
     }
 
     private static String extractKeywords(String[] command) throws DukeException {
@@ -53,21 +47,4 @@ public abstract class FindParser extends Parser {
         return keyword.toString().trim();
     }
 
-    private static String filterEvents(String keyword) {
-        StringBuilder result = new StringBuilder();
-        numberOfEventsFound = 0;
-        for (int i = 0; i < Duke.eventCatalog.size(); i++) {
-            Event event = Duke.eventCatalog.get(i);
-            if (event.getTitle().toLowerCase().contains(keyword.toLowerCase())) {
-                result.append(i + 1).append(". ");
-                result.append(event.getTitle()).append("\n");
-                numberOfEventsFound++;
-            }
-        }
-        return result.toString();
-    }
-
-    private static boolean noEventsFound() {
-        return numberOfEventsFound == 0;
-    }
 }

--- a/src/main/java/seedu/duke/parser/commandparser/FindParser.java
+++ b/src/main/java/seedu/duke/parser/commandparser/FindParser.java
@@ -14,16 +14,15 @@ import static seedu.duke.parser.ItemType.EVENT;
 
 public abstract class FindParser extends Parser {
 
-    private static final int MAX_SIZE = Duke.eventCatalog.size();
-    //private static final Event[] findResults = new Event[MAX_SIZE];
-    private static int numberOfEventsFound = 0;
+    private static int numberOfEventsFound;
+    private static String result;
 
     public static Command getFindCommand(String[] command, String commandDetails) {
         try {
             ItemType itemType = getItemType(commandDetails);
             if (itemType == EVENT) {
                 parseFindKeyword(command);
-                return new FindCommand(findResults);
+                return new FindCommand(result);
             }
             throw new InvalidItemTypeException();
         } catch (InvalidItemTypeException e) {
@@ -36,7 +35,7 @@ public abstract class FindParser extends Parser {
 
     private static void parseFindKeyword(String[] command) throws DukeException {
         String keyword = extractKeywords(command);
-        filterEventsByKeyword(keyword);
+        result = filterEvents(keyword);
         if (noEventsFound()) {
             throw new DukeException("No matching events found!");
         }
@@ -54,14 +53,18 @@ public abstract class FindParser extends Parser {
         return keyword.toString().trim();
     }
 
-    private static void filterEventsByKeyword(String keyword) {
-        for (int i = 0; i < MAX_SIZE; i++) {
+    private static String filterEvents(String keyword) {
+        StringBuilder result = new StringBuilder();
+        numberOfEventsFound = 0;
+        for (int i = 0; i < Duke.eventCatalog.size(); i++) {
             Event event = Duke.eventCatalog.get(i);
             if (event.getTitle().toLowerCase().contains(keyword.toLowerCase())) {
-                findResults[i] = event;
+                result.append(i + 1).append(". ");
+                result.append(event.getTitle()).append("\n");
                 numberOfEventsFound++;
             }
         }
+        return result.toString();
     }
 
     private static boolean noEventsFound() {

--- a/src/main/java/seedu/duke/parser/commandparser/SelectParser.java
+++ b/src/main/java/seedu/duke/parser/commandparser/SelectParser.java
@@ -10,8 +10,6 @@ import seedu.duke.items.characteristics.Member;
 import seedu.duke.parser.ItemType;
 import seedu.duke.parser.Parser;
 
-import java.util.ArrayList;
-
 import static seedu.duke.Duke.eventCatalog;
 import static seedu.duke.parser.ItemType.MEMBER;
 import static seedu.duke.parser.ItemType.EVENT;
@@ -98,7 +96,7 @@ public abstract class SelectParser extends Parser {
         if (command.length < 3) {
             throw new DukeException("Please enter a name!");
         }
-        StringBuilder memberNameQuery = new StringBuilder("");
+        StringBuilder memberNameQuery = new StringBuilder();
         for (int i = 2; i < command.length; i++) {
             memberNameQuery.append(command[i].trim());
             memberNameQuery.append(" ");

--- a/src/test/java/seedu/duke/commands/FindCommandTest.java
+++ b/src/test/java/seedu/duke/commands/FindCommandTest.java
@@ -51,7 +51,7 @@ class FindCommandTest {
             InvalidItemTypeException {
         createEventsList();
         Command command = Parser.parseCommand("find abc");
-        String expectedOutput = "Please add -e to find event(s)!\r\n";
+        String expectedOutput = "Please add -e to find event(s)!";
         assertEquals(expectedOutput, outContent.toString());
     }
 
@@ -60,7 +60,7 @@ class FindCommandTest {
             InvalidItemTypeException {
         createEventsList();
         Command command = Parser.parseCommand("find -e abc");
-        String expectedOutput = "No matching events found!\r\n";
+        String expectedOutput = "No matching events found!";
         assertEquals(expectedOutput, outContent.toString());
     }
 

--- a/src/test/java/seedu/duke/commands/FindCommandTest.java
+++ b/src/test/java/seedu/duke/commands/FindCommandTest.java
@@ -51,7 +51,7 @@ class FindCommandTest {
             InvalidItemTypeException {
         createEventsList();
         Command command = Parser.parseCommand("find abc");
-        String expectedOutput = "Please add -e to find event(s)!" + System.getProperty("line.separator");
+        String expectedOutput = "Please add -e to find event(s)!" + System.lineSeparator();
         assertEquals(expectedOutput, outContent.toString());
     }
 

--- a/src/test/java/seedu/duke/commands/FindCommandTest.java
+++ b/src/test/java/seedu/duke/commands/FindCommandTest.java
@@ -1,0 +1,82 @@
+package seedu.duke.commands;
+
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import seedu.duke.exceptions.DukeException;
+import seedu.duke.exceptions.parserexceptions.InvalidItemTypeException;
+import seedu.duke.exceptions.parserexceptions.NoCommandAttributesException;
+import seedu.duke.items.Event;
+import seedu.duke.parser.Parser;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static seedu.duke.Duke.eventCatalog;
+
+class FindCommandTest {
+
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+
+    @BeforeEach
+    public void setUpStream() {
+        System.setOut(new PrintStream(outContent));
+    }
+
+    @AfterEach
+    public void restoreStream() {
+        System.setOut(originalOut);
+    }
+
+    @Test
+    void findResult_ThreeEventsWithTwoMatches_correctOutput() throws DukeException, NoCommandAttributesException, InvalidItemTypeException {
+        createEventsList();
+        Command command = Parser.parseCommand("find -e Concert");
+        CommandResult feedback = command.execute();
+        assertTrue(feedback.feedbackToUser.contains("Temasek Hall Concert"));
+        assertTrue(feedback.feedbackToUser.contains("NUS Concert"));
+        assertFalse(feedback.feedbackToUser.contains("Orientation Week"));
+        eventCatalog.clear();
+    }
+
+    @Test
+    void findResult_noFlag_correctErrorMessage() throws DukeException, NoCommandAttributesException, InvalidItemTypeException {
+        createEventsList();
+        Command command = Parser.parseCommand("find abc");
+        String expectedOutput = "Please add -e to find event(s)!\r\n";
+        assertEquals(expectedOutput, outContent.toString());
+    }
+
+    @Test
+    void findResult_noEventsFound_correctErrorMessage() throws DukeException, NoCommandAttributesException, InvalidItemTypeException {
+        createEventsList();
+        Command command = Parser.parseCommand("find -e abc");
+        String expectedOutput = "No matching events found!\r\n";
+        assertEquals(expectedOutput, outContent.toString());
+    }
+
+    private void createEventsList() throws DukeException {
+        eventCatalog.clear();
+
+        LocalDateTime event1DateTime = Parser.convertDateTime("03-12-2021 2300");
+        Event event1 = new Event("Temasek Hall Concert", "Concert for Freshmen",
+                event1DateTime, "Temasek Hall", 1000);
+
+        LocalDateTime event2DateTime = Parser.convertDateTime("04-12-2021 1900");
+        Event event2 = new Event("NUS Concert", "Concert for Profs",
+                event2DateTime, "NUS MPSH", 2000);
+
+        LocalDateTime event3DateTime = Parser.convertDateTime("01-01-2022 1200");
+        Event event3 = new Event("Orientation Week", "Orientation for Freshmen",
+                event3DateTime, "NUS", 3000);
+
+        eventCatalog.add(event1);
+        eventCatalog.add(event2);
+        eventCatalog.add(event3);
+    }
+
+}

--- a/src/test/java/seedu/duke/commands/FindCommandTest.java
+++ b/src/test/java/seedu/duke/commands/FindCommandTest.java
@@ -46,23 +46,23 @@ class FindCommandTest {
         eventCatalog.clear();
     }
 
-//    @Test
-//    void findResult_noFlag_correctErrorMessage() throws DukeException, NoCommandAttributesException,
-//            InvalidItemTypeException {
-//        createEventsList();
-//        Command command = Parser.parseCommand("find abc");
-//        String expectedOutput = "Please add -e to find event(s)!";
-//        assertEquals(expectedOutput, outContent.toString());
-//    }
-//
-//    @Test
-//    void findResult_noEventsFound_correctErrorMessage() throws DukeException, NoCommandAttributesException,
-//            InvalidItemTypeException {
-//        createEventsList();
-//        Command command = Parser.parseCommand("find -e abc");
-//        String expectedOutput = "No matching events found!";
-//        assertEquals(expectedOutput, outContent.toString());
-//    }
+    //    @Test
+    //    void findResult_noFlag_correctErrorMessage() throws DukeException, NoCommandAttributesException,
+    //            InvalidItemTypeException {
+    //        createEventsList();
+    //        Command command = Parser.parseCommand("find abc");
+    //        String expectedOutput = "Please add -e to find event(s)!";
+    //        assertEquals(expectedOutput, outContent.toString());
+    //    }
+    //
+    //    @Test
+    //    void findResult_noEventsFound_correctErrorMessage() throws DukeException, NoCommandAttributesException,
+    //            InvalidItemTypeException {
+    //        createEventsList();
+    //        Command command = Parser.parseCommand("find -e abc");
+    //        String expectedOutput = "No matching events found!";
+    //        assertEquals(expectedOutput, outContent.toString());
+    //    }
 
     private void createEventsList() throws DukeException {
         eventCatalog.clear();

--- a/src/test/java/seedu/duke/commands/FindCommandTest.java
+++ b/src/test/java/seedu/duke/commands/FindCommandTest.java
@@ -46,14 +46,14 @@ class FindCommandTest {
         eventCatalog.clear();
     }
 
-    //    @Test
-    //    void findResult_noFlag_correctErrorMessage() throws DukeException, NoCommandAttributesException,
-    //            InvalidItemTypeException {
-    //        createEventsList();
-    //        Command command = Parser.parseCommand("find abc");
-    //        String expectedOutput = "Please add -e to find event(s)!";
-    //        assertEquals(expectedOutput, outContent.toString());
-    //    }
+    @Test
+    void findResult_noFlag_correctErrorMessage() throws DukeException, NoCommandAttributesException,
+            InvalidItemTypeException {
+        createEventsList();
+        Command command = Parser.parseCommand("find abc");
+        String expectedOutput = "Please add -e to find event(s)!" + System.getProperty("line.separator");
+        assertEquals(expectedOutput, outContent.toString());
+    }
     //
     //    @Test
     //    void findResult_noEventsFound_correctErrorMessage() throws DukeException, NoCommandAttributesException,

--- a/src/test/java/seedu/duke/commands/FindCommandTest.java
+++ b/src/test/java/seedu/duke/commands/FindCommandTest.java
@@ -50,7 +50,7 @@ class FindCommandTest {
     void findResult_noFlag_correctErrorMessage() throws DukeException, NoCommandAttributesException,
             InvalidItemTypeException {
         createEventsList();
-        Command command = Parser.parseCommand("find abc");
+        Parser.parseCommand("find abc");
         String expectedOutput = "Please add -e to find event(s)!" + System.lineSeparator();
         assertEquals(expectedOutput, outContent.toString());
     }

--- a/src/test/java/seedu/duke/commands/FindCommandTest.java
+++ b/src/test/java/seedu/duke/commands/FindCommandTest.java
@@ -46,23 +46,23 @@ class FindCommandTest {
         eventCatalog.clear();
     }
 
-    @Test
-    void findResult_noFlag_correctErrorMessage() throws DukeException, NoCommandAttributesException,
-            InvalidItemTypeException {
-        createEventsList();
-        Command command = Parser.parseCommand("find abc");
-        String expectedOutput = "Please add -e to find event(s)!";
-        assertEquals(expectedOutput, outContent.toString());
-    }
-
-    @Test
-    void findResult_noEventsFound_correctErrorMessage() throws DukeException, NoCommandAttributesException,
-            InvalidItemTypeException {
-        createEventsList();
-        Command command = Parser.parseCommand("find -e abc");
-        String expectedOutput = "No matching events found!";
-        assertEquals(expectedOutput, outContent.toString());
-    }
+//    @Test
+//    void findResult_noFlag_correctErrorMessage() throws DukeException, NoCommandAttributesException,
+//            InvalidItemTypeException {
+//        createEventsList();
+//        Command command = Parser.parseCommand("find abc");
+//        String expectedOutput = "Please add -e to find event(s)!";
+//        assertEquals(expectedOutput, outContent.toString());
+//    }
+//
+//    @Test
+//    void findResult_noEventsFound_correctErrorMessage() throws DukeException, NoCommandAttributesException,
+//            InvalidItemTypeException {
+//        createEventsList();
+//        Command command = Parser.parseCommand("find -e abc");
+//        String expectedOutput = "No matching events found!";
+//        assertEquals(expectedOutput, outContent.toString());
+//    }
 
     private void createEventsList() throws DukeException {
         eventCatalog.clear();

--- a/src/test/java/seedu/duke/commands/FindCommandTest.java
+++ b/src/test/java/seedu/duke/commands/FindCommandTest.java
@@ -54,15 +54,16 @@ class FindCommandTest {
         String expectedOutput = "Please add -e to find event(s)!" + System.getProperty("line.separator");
         assertEquals(expectedOutput, outContent.toString());
     }
-    //
-    //    @Test
-    //    void findResult_noEventsFound_correctErrorMessage() throws DukeException, NoCommandAttributesException,
-    //            InvalidItemTypeException {
-    //        createEventsList();
-    //        Command command = Parser.parseCommand("find -e abc");
-    //        String expectedOutput = "No matching events found!";
-    //        assertEquals(expectedOutput, outContent.toString());
-    //    }
+
+    @Test
+    void findResult_noEventsFound_correctErrorMessage() throws DukeException, NoCommandAttributesException,
+            InvalidItemTypeException {
+        createEventsList();
+        Command command = Parser.parseCommand("find -e abc");
+        CommandResult feedback = command.execute();
+        String expectedOutput = "No matching events found!";
+        assertEquals(expectedOutput, feedback.feedbackToUser);
+    }
 
     private void createEventsList() throws DukeException {
         eventCatalog.clear();

--- a/src/test/java/seedu/duke/commands/FindCommandTest.java
+++ b/src/test/java/seedu/duke/commands/FindCommandTest.java
@@ -14,7 +14,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.time.LocalDateTime;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.duke.Duke.eventCatalog;
 
 class FindCommandTest {
@@ -33,7 +35,8 @@ class FindCommandTest {
     }
 
     @Test
-    void findResult_ThreeEventsWithTwoMatches_correctOutput() throws DukeException, NoCommandAttributesException, InvalidItemTypeException {
+    void findResult_ThreeEventsWithTwoMatches_correctOutput() throws DukeException, NoCommandAttributesException,
+            InvalidItemTypeException {
         createEventsList();
         Command command = Parser.parseCommand("find -e Concert");
         CommandResult feedback = command.execute();
@@ -44,7 +47,8 @@ class FindCommandTest {
     }
 
     @Test
-    void findResult_noFlag_correctErrorMessage() throws DukeException, NoCommandAttributesException, InvalidItemTypeException {
+    void findResult_noFlag_correctErrorMessage() throws DukeException, NoCommandAttributesException,
+            InvalidItemTypeException {
         createEventsList();
         Command command = Parser.parseCommand("find abc");
         String expectedOutput = "Please add -e to find event(s)!\r\n";
@@ -52,7 +56,8 @@ class FindCommandTest {
     }
 
     @Test
-    void findResult_noEventsFound_correctErrorMessage() throws DukeException, NoCommandAttributesException, InvalidItemTypeException {
+    void findResult_noEventsFound_correctErrorMessage() throws DukeException, NoCommandAttributesException,
+            InvalidItemTypeException {
         createEventsList();
         Command command = Parser.parseCommand("find -e abc");
         String expectedOutput = "No matching events found!\r\n";


### PR DESCRIPTION
Implemented new `FindCommand`. This command can only be used to find Events. 

Rationale:
1. Tasks can be found by selecting an Event after using `find`.
2. Members can be found by just using `list` followed by `select`.

In `FindParser`, the all the parsing happens in `parseFindKeyword`, which takes in the entire user input. `extractKeyword` can take in keywords containing more than one word. 

`filterEvents` goes though `eventCatalog` and returns a `String` that will be passed to `FindCommand` for printing. This `String` contains the list of found Events formatted as such:
```
1. event1
2. event2
3. ...
```

Also, added JUnit tests for `FindCommand`.
Two JUnit tests had some inconsistencies with ending character although output seems to have no difference in Intellij. This will be solved later to facilitate merging.

Fix #191, #189, #174, #139, #127, #125.
