### PR TITLE
Fix bug whereby task decoder was creating new duplicate member objects

### DIFF
--- a/src/main/java/seedu/duke/storage/TaskDecoder.java
+++ b/src/main/java/seedu/duke/storage/TaskDecoder.java
@@ -56,9 +56,13 @@ public class TaskDecoder {
         String[] formattedMemberNamesInString = MemberParser.parseMemberCommand(encodedMembers);
         ArrayList<Member> membersList = new ArrayList<>();
         for (String name : formattedMemberNamesInString) {
-            membersList.add(new Member(name));
+            // If the member in the member roster matches the decoded name, assign this member to the task
+            for (Member member : Duke.memberRoster) {
+                if (member.getName().equals(name)) {
+                    membersList.add(member);
+                }
+            }
         }
-
         return membersList;
     }
 


### PR DESCRIPTION
The `decodeTaskFromString` method was modified to use references of `Member` objects instead of creating new ones when decoding member-related data from the save file.

Fixes #200 